### PR TITLE
Only download safetensors metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,7 +594,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -642,13 +660,13 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 [[package]]
 name = "hf-hub"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112fa2f6ad4ab815b9e1b938b4b1e437032d055e2f92ed10fd6ab2e62d02c6b6"
+source = "git+https://github.com/danieldk/hf-hub?branch=st-browser-needed-functions#347fd8e2a9bbbd26bee1c1f64c73162db02d275f"
 dependencies = [
  "dirs",
  "futures",
  "http",
  "indicatif",
+ "libc",
  "log",
  "native-tls",
  "num_cpus",
@@ -659,6 +677,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "ureq",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1069,15 +1088,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memmap2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1119,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1358,7 +1368,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1397,7 +1407,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -1456,7 +1466,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -1549,21 +1559,25 @@ dependencies = [
 name = "safetensors-browser"
 version = "0.1.0"
 dependencies = [
+ "base32",
+ "bytes",
  "clap",
  "color-eyre",
  "crossterm",
+ "fnv",
  "futures",
  "fuzzy-matcher",
  "hf-hub",
  "indicatif",
- "memmap2",
  "num-bigint",
  "ratatui",
  "reqwest",
  "safetensors",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
+ "xdg",
 ]
 
 [[package]]
@@ -1835,13 +1849,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2159,6 +2173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +2495,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +2514,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,22 @@ edition = "2021"
 description = "Browser for Safetensors checkpoints"
 
 [dependencies]
+base32 = "0.5"
+bytes = "1.9.0"
 clap = { version = "4.5.27", features = ["derive"] }
 color-eyre = "0.6.3"
 crossterm = "0.28.1"
+fnv = "1.0.7"
 futures = "0.3.31"
 fuzzy-matcher = "0.3.7"
-hf-hub = "0.4.1"
+hf-hub = { git = "https://github.com/danieldk/hf-hub", branch = "st-browser-needed-functions" }
 indicatif = "0.17.9"
-memmap2 = "0.9.5"
 num-bigint = "0.4.6"
 ratatui = "0.29.0"
 reqwest = "0.12.12"
 safetensors = "0.5.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3.16.0"
 tokio = "1.43.0"
+xdg = "2.5.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::HashMap, ffi::OsStr};
+use std::collections::HashMap;
 
 use color_eyre::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind};
@@ -226,14 +226,7 @@ impl App {
                 Line::from(vec![Span::styled("Name: ", field_style), Span::raw(name)]),
                 Line::from(vec![
                     Span::styled("File: ", field_style),
-                    Span::raw(
-                        metadata
-                            .checkpoint
-                            .file_name()
-                            .map(OsStr::to_string_lossy)
-                            // This shouldn't happen.
-                            .unwrap_or_else(|| Cow::Borrowed("unknown")),
-                    ),
+                    Span::raw(metadata.checkpoint.clone()),
                 ]),
                 Line::from(vec![
                     Span::styled("DType: ", field_style),

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,67 +1,160 @@
-use std::{
-    collections::{BTreeSet, HashMap},
-    fs::File,
-    io::BufReader,
-    path::PathBuf,
-};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
 
+use bytes::Buf;
 use color_eyre::eyre::{Context, Result};
 use futures::future::try_join_all;
-use hf_hub::{
-    api::tokio::{Api, ApiError, ApiRepo, Progress},
-    Cache, Repo,
-};
-use indicatif::{MultiProgress, ProgressBar};
+use hf_hub::api::tokio::{Api, ApiError, ApiRepo};
+use hf_hub::{CacheRepo, Repo};
+use indicatif::ProgressBar;
 use reqwest::StatusCode;
+use safetensors::tensor::Metadata;
 use serde::Deserialize;
+use tempfile::NamedTempFile;
+
+use crate::utils::symlink_or_rename;
+
+const MAX_CONCURRENT: usize = 8;
 
 #[derive(Debug, Deserialize)]
 struct Index {
     pub weight_map: HashMap<String, String>,
 }
 
+pub struct CheckpointMetadata {
+    pub filename: String,
+    pub metadata: Metadata,
+}
+
 pub struct SafeTensorsRepo {
-    repo: Repo,
+    api: Api,
     api_repo: ApiRepo,
+    cache_repo: CacheRepo,
 }
 
 impl SafeTensorsRepo {
-    pub fn new(api: &Api, repo: Repo) -> Self {
+    pub fn new(api: &Api, repo: Repo, cache_repo: CacheRepo) -> Self {
         let api_repo = api.repo(repo.clone());
-        Self { repo, api_repo }
+        Self {
+            api: api.clone(),
+            api_repo,
+            cache_repo,
+        }
     }
 
-    pub async fn get_checkpoint_paths(&self) -> Result<Vec<PathBuf>> {
+    async fn download_file(&self, filename: &str) -> Result<CheckpointMetadata> {
+        let url = self.api_repo.url(filename);
+        let url_metadata = self.api.metadata(&url).await?;
+        let blob_path = self.cache_repo.blob_path(&url_metadata.etag);
+
+        let client = self.api.client();
+        let header_size_response = client.get(&url).header("RANGE", "bytes=0-7").send().await?;
+        let mut header_size_bytes = header_size_response.bytes().await?;
+        let header_size = header_size_bytes.get_u64_le();
+
+        let metadata_response = client
+            .get(&url)
+            .header("RANGE", format!("bytes=8-{}", header_size + 7))
+            .send()
+            .await?;
+
+        let metadata_bytes = metadata_response.bytes().await?.to_vec();
+        let metadata: Metadata = serde_json::from_slice(&metadata_bytes)?;
+
+        let mut tempfile = NamedTempFile::new()?;
+
+        {
+            let mut writer = BufWriter::new(&mut tempfile);
+            writer.write_all(&header_size.to_le_bytes())?;
+            writer.write_all(&metadata_bytes)?;
+        }
+
+        std::fs::create_dir_all(blob_path.parent().unwrap())?;
+        std::fs::copy(tempfile.path(), &blob_path)?;
+
+        let mut pointer_path = self.cache_repo.pointer_path(&url_metadata.commit_hash);
+        std::fs::create_dir_all(&pointer_path)?;
+        pointer_path.push(filename);
+        symlink_or_rename(&blob_path, &pointer_path)?;
+        self.cache_repo.create_ref(&url_metadata.commit_hash)?;
+
+        Ok(CheckpointMetadata {
+            filename: filename.to_owned(),
+            metadata,
+        })
+    }
+
+    fn file_from_cache(&self, filename: &str) -> Result<Option<CheckpointMetadata>> {
+        let metadata_path = match self.cache_repo.get(filename) {
+            Some(path) => path,
+            None => return Ok(None),
+        };
+
+        let f = File::open(metadata_path)?;
+        let mut reader = BufReader::new(f);
+        let mut metadata_length_bytes = [0; 8];
+        match reader.read_exact(&mut metadata_length_bytes) {
+            Ok(_) => (),
+            Err(_) => return Ok(None),
+        };
+
+        let metadata_length = u64::from_le_bytes(metadata_length_bytes);
+        let mut metadata_bytes = vec![0; metadata_length as usize];
+        match reader.read_exact(&mut metadata_bytes) {
+            Ok(_) => (),
+            Err(_) => return Ok(None),
+        }
+
+        match serde_json::from_slice(&metadata_bytes) {
+            Ok(metadata) => Ok(Some(CheckpointMetadata {
+                metadata,
+                filename: filename.to_owned(),
+            })),
+            Err(_) => Ok(None),
+        }
+    }
+
+    async fn get_file(
+        &self,
+        filename: String,
+        progress: &ProgressBar,
+    ) -> Result<CheckpointMetadata> {
+        let metadata = match self.file_from_cache(&filename)? {
+            Some(metadata) => metadata,
+            None => self.download_file(&filename).await?,
+        };
+        progress.inc(1);
+        Ok(metadata)
+    }
+
+    pub async fn get_checkpoint_metadatas(&self) -> Result<Vec<CheckpointMetadata>> {
         let checkpoints = self.get_safetensors_index().await?;
 
-        let multi_pg = MultiProgress::new();
+        let progress = ProgressBar::new(checkpoints.len() as u64);
+        progress.tick();
 
+        let info = self.api_repo.info().await?;
+        self.cache_repo.create_ref(&info.sha)?;
+
+        let mut results = Vec::new();
         let mut tasks = Vec::new();
         for checkpoint in checkpoints {
-            let pb_task = multi_pg.add(ProgressBar::new(100));
-            tasks.push(self.get_with_progress(checkpoint, pb_task));
+            tasks.push(self.get_file(checkpoint, &progress));
+
+            if tasks.len() == MAX_CONCURRENT {
+                results.extend(try_join_all(tasks).await?);
+                tasks = Vec::new();
+            }
         }
 
-        Ok(try_join_all(tasks).await?)
-    }
-
-    async fn get_with_progress<P>(
-        &self,
-        filename: impl AsRef<str>,
-        progress: P,
-    ) -> Result<PathBuf, ApiError>
-    where
-        P: Progress + Clone + Send + Sync + 'static,
-    {
-        let filename = filename.as_ref();
-        let cache = Cache::from_env();
-        if let Some(path) = cache.repo(self.repo.clone()).get(filename) {
-            Ok(path)
-        } else {
-            self.api_repo
-                .download_with_progress(filename, progress)
-                .await
+        if !tasks.is_empty() {
+            results.extend(try_join_all(tasks).await?);
         }
+
+        progress.finish();
+
+        Ok(results)
     }
 
     async fn get_safetensors_index(&self) -> Result<Vec<String>> {
@@ -81,7 +174,7 @@ impl SafeTensorsRepo {
         ))?);
 
         let index: Index = serde_json::from_reader(reader)?;
-        let checkpoint_set = index.weight_map.into_values().collect::<BTreeSet<_>>();
+        let checkpoint_set = index.weight_map.into_values().collect::<HashSet<_>>();
         Ok(checkpoint_set.into_iter().collect())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,57 @@
+use std::path::{Component, Path, PathBuf};
+
+// Utility functions below are from hf-hub-rs.
+
+pub(crate) fn symlink_or_rename(src: &Path, dst: &Path) -> Result<(), std::io::Error> {
+    if dst.exists() {
+        return Ok(());
+    }
+
+    let rel_src = make_relative(src, dst);
+    #[cfg(target_os = "windows")]
+    {
+        if std::os::windows::fs::symlink_file(rel_src, dst).is_err() {
+            std::fs::rename(src, dst)?;
+        }
+    }
+
+    #[cfg(target_family = "unix")]
+    std::os::unix::fs::symlink(rel_src, dst)?;
+
+    Ok(())
+}
+
+fn make_relative(src: &Path, dst: &Path) -> PathBuf {
+    let path = src;
+    let base = dst;
+
+    assert_eq!(
+        path.is_absolute(),
+        base.is_absolute(),
+        "This function is made to look at absolute paths only"
+    );
+    let mut ita = path.components();
+    let mut itb = base.components();
+
+    loop {
+        match (ita.next(), itb.next()) {
+            (Some(a), Some(b)) if a == b => (),
+            (some_a, _) => {
+                // Ignoring b, because 1 component is the filename
+                // for which we don't need to go back up for relative
+                // filename to work.
+                let mut new_path = PathBuf::new();
+                for _ in itb {
+                    new_path.push(Component::ParentDir);
+                }
+                if let Some(a) = some_a {
+                    new_path.push(a);
+                    for comp in ita {
+                        new_path.push(comp);
+                    }
+                }
+                return new_path;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change makes the initial download step a lot faster and less wasteful of space. Rather than downloading full checkpoints, we now only download the metadata.

To ensure that we are not leaving corrupted HF caches, the cached metadata is now stored in the `safetensors-browser` XDG cache directory.