### PR TITLE
fix: enable local run with qwen model

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
 
     // For quantization, we'd rather not show any information than
     // fail when we don't know the quantization method.
-    #[serde(deserialize_with = "ok_or_none")]
+    #[serde(default, deserialize_with = "ok_or_none")]
     pub quantization_config: Option<QuantizationConfig>,
 }
 


### PR DESCRIPTION
This PR adds small changes to allow `safetensor-browser` run locally 

1. adds default to quantization config

existing issue
```bash
cargo run --release -- Qwen/Qwen2-VL-7B-Instruct
    Finished `release` profile [optimized] target(s) in 0.11s
     Running `target/release/safetensors-browser Qwen/Qwen2-VL-7B-Instruct`
Error:
   0: missing field `quantization_config` at line 52 column 1

Location:
   src/repo.rs:167

Backtrace omitted. Run with RUST_BACKTRACE=1 environment 
```

2.  adds nightly toolchain to avoid 

```bash
error[E0658]: use of unstable library feature 'error_in_core'
  --> /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/safetensors-0.5.2/src/tensor.rs:67:6
   |
67 | impl core::error::Error for SafeTensorError {}
   |      ^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #103765 <https://github.com/rust-lang/rust/issues/103765> for more information

For more information about this error, try `rustc --explain E0658`.

```
