### PR TITLE
fix: enable local run with qwen model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Daniël de Kok <me@danieldk.eu>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Browser for Safetensors checkpoints"
+rust-version = "1.81"
 
 [dependencies]
 base32 = "0.5"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ pub struct Config {
 
     // For quantization, we'd rather not show any information than
     // fail when we don't know the quantization method.
-    #[serde(deserialize_with = "ok_or_none")]
+    #[serde(default, deserialize_with = "ok_or_none")]
     pub quantization_config: Option<QuantizationConfig>,
 }
 


### PR DESCRIPTION
* Set minimum Rust version to 1.81.
* Fix Qwen support by setting quantization config deserialization to `default`.